### PR TITLE
Prevent duplicated repo additions.

### DIFF
--- a/init
+++ b/init
@@ -28,7 +28,10 @@ get_iso_build_date () {
 }
 
 init_archzfs () {
-
+    if pacman -Sl archzfs >/dev/null 2>&1; then
+        print "archzfs repo was already added"
+        return
+    fi
     print "Adding archzfs repo"
     
     pacman -Sy archlinux-keyring --noconfirm &>/dev/null


### PR DESCRIPTION
When the script gets run multiple times, it keeps adding the repo to `/etc/pacman.conf`.
This fixes that bug.