### PR TITLE
Make the archiso check slightly more relaxed

### DIFF
--- a/init
+++ b/init
@@ -124,7 +124,7 @@ download_package () {
 
 print "Testing if archiso is running"
 
-grep archiso /proc/cmdline >/dev/null
+grep 'arch.*iso' /proc/cmdline >/dev/null
 
 print "Increasing cowspace to half of RAM"
 


### PR DESCRIPTION
With this fix it also becomes possible to use a straight up live iso from grub as described here: https://openzfs.github.io/openzfs-docs/Getting%20Started/Arch%20Linux/Root%20on%20ZFS/4-optional-configuration.html#boot-live-iso-with-grub

Instead of archiso...iso that file is called archlinux...iso