### PR TITLE
fix #17 dkms fallback

### DIFF
--- a/init
+++ b/init
@@ -181,6 +181,8 @@ zfslinux_install () {
                 return 1
             fi
         fi
+    else
+        return 1
     fi
 
     return 0


### PR DESCRIPTION
fix dkms fallback which wasn't triggered when early fail in zfslinux_install function, because of a wrong return code.